### PR TITLE
Fix requirements. It seems these repos were moved

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ tox
 pyusb
 -e git+https://github.com/amaranth-lang/amaranth.git#egg=amaranth
 -e git+https://github.com/amaranth-lang/amaranth-soc.git#egg=amaranth-soc
--e git+https://github.com/hansfbaier/amaranth-boards.git#egg=amaranth_boards
+-e git+https://github.com/amaranth-community-unofficial/amaranth-boards.git#egg=amaranth_boards
 -e git+https://github.com/amaranth-community-unofficial/amlib.git#egg=amlib
 -e git+https://github.com/lambdaconcept/minerva.git#egg=minerva
 -e git+https://github.com/lambdaconcept/lambdasoc.git#egg=lambdasoc
--e git+https://github.com/hansfbaier/python-usb-descriptors.git#egg=usb_descriptors
+-e git+https://github.com/amaranth-community-unofficial/python-usb-descriptors.git#egg=usb_descriptors
 -e git+https://github.com/greatscottgadgets/apollo.git#egg=apollo-fpga
 pyvcd
 pyserial~=3.4


### PR DESCRIPTION
Not sure if there is something wrong with my setup, but I am always facing issues with the installation of the usb-descriptors, so I have to change it to use amarant-community-unofficial. When adjusting already, I thought it might be good to adjust the dependency for amaranth-boards accordingly.

Thanks!